### PR TITLE
Closure-compiler format and windows support

### DIFF
--- a/tasks/google_closure_compiler.js
+++ b/tasks/google_closure_compiler.js
@@ -15,6 +15,7 @@ module.exports = function (grunt) {
   var exec = require('child_process').exec;
   var fs = require('fs');
   var _isUndefined = require('lodash/lang/isUndefined');
+  var _isWin = /^win/.test(process.platform)
 
   var possible_options = {
     compilation_level: ['SIMPLE', 'ADVANCED', 'WHITESPACE_ONLY'],
@@ -36,20 +37,21 @@ module.exports = function (grunt) {
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      closure_compilation_level: 'SIMPLE',
-      closure_create_source_map: true,
-      closure_language_in: null,
-      closure_language_out: null,
-      closure_formatting: null,
-      closure_debug: false,
-      closure_extra_param: null,
+      compilation_level: 'SIMPLE',
+      create_source_map: true,
+      language_in: null,
+      language_out: null,
+      formatting: null,
+      debug: false,
+      extra_param: null,
+      output_wrapper: null,
       banner: '',
       report_file: '',
       compiler_jar: 'node_modules/google-closure-compiler/compiler.jar',
       exec_maxBuffer: 200,
       java_path: null,
       java_d32: false,
-      java_tieredcompilation: true
+      java_tieredcompilation: (_isWin ? false: true)
     });
 
     // Check if the compiler_jar property is empty
@@ -64,37 +66,37 @@ module.exports = function (grunt) {
       compileDone(false);
     }
 
-    if (possible_options.compilation_level.indexOf(options.closure_compilation_level) === -1) {
+    if (possible_options.compilation_level.indexOf(options.compilation_level) === -1) {
       grunt.fail.warn('Wrong value for compilation level. (Possible values: ' + possible_options.compilation_level.join(',') + ')');
       compileDone(false);
     }
 
-    if (options.closure_language_in !== null) {
-      if (possible_options.language_in.indexOf(options.closure_language_in) === -1) {
+    if (options.language_in !== null) {
+      if (possible_options.language_in.indexOf(options.language_in) === -1) {
         grunt.fail.warn('Wrong value for language in. (Possible values: ' + possible_options.language_in.join(',') + ')');
         compileDone(false);
       }
     }
 
-    if (options.closure_language_out !== null) {
-      if (possible_options.language_out.indexOf(options.closure_language_out) === -1) {
+    if (options.language_out !== null) {
+      if (possible_options.language_out.indexOf(options.language_out) === -1) {
         grunt.fail.warn('Wrong value for language out. (Possible values: ' + possible_options.language_out.join(',') + ')');
         compileDone(false);
       }
     }
 
-    if (options.closure_formatting !== null) {
-      if (possible_options.formatting.indexOf(options.closure_formatting) === -1) {
+    if (options.formatting !== null) {
+      if (possible_options.formatting.indexOf(options.formatting) === -1) {
         grunt.fail.warn('Wrong value for formatting. (Possible values: ' + possible_options.formatting.join(',') + ')');
         compileDone(false);
       }
     }
 
-    var java_path = 'java';
+    var java_path = 'java' + (_isWin ? 'w' : '');
 
     // If we have setted JAVA_HOME we would prefer this
     if (!_isUndefined(process.env.JAVA_HOME)) {
-      java_path = process.env.JAVA_HOME + '/bin/java';
+      java_path = process.env.JAVA_HOME + '/bin/java' + (_isWin ? 'w' : '');
     }
 
     // At least the user can set it by config
@@ -103,7 +105,7 @@ module.exports = function (grunt) {
     }
 
     // Java command with optional parameters
-    var command = java_path + ' ' +
+    var java_command = java_path + ' ' +
             (options.java_d32 === true ? '-client -d32 ' : '') +
             (options.java_tieredcompilation === true ? '-server -XX:+TieredCompilation ' : '') +
             '-jar "' + options.compiler_jar + '"';
@@ -132,57 +134,76 @@ module.exports = function (grunt) {
       });
 
       var javascript_files = '--js="' + fileInputArray.join('" --js="') + '"';
-      var closure_command = command + ' ' + javascript_files + ' --js_output_file="' + output_file + '"';
+      var command_line = '';
+
+      if (_isWin) {
+        if (typeof options.output_wrapper === 'string') {
+          options.output_wrapper = options.output_wrapper.replace(/[\r\n]+/,' ');
+        }
+      }
+
+      command_line += java_command + ' ' + javascript_files + ' --js_output_file="' + output_file + '"';
 
       // Add compilation level
-      closure_command += ' --compilation_level="' + options.closure_compilation_level + '"';
+      command_line += ' --compilation_level="' + options.compilation_level + '"';
 
       // Add source map param if necessary
-      if (options.closure_create_source_map === true) {
-        closure_command += ' --create_source_map="' + output_mapfile + '"';
+      if (options.create_source_map === true) {
+        command_line += ' --create_source_map="' + output_mapfile + '"';
       }
 
-      if (options.closure_language_in !== null) {
-        closure_command += ' --language_in="' + options.closure_language_in + '"';
+      if (options.language_in !== null) {
+        command_line += ' --language_in="' + options.language_in + '"';
       }
 
-      if (options.closure_language_out !== null) {
-        closure_command += ' --language_out="' + options.closure_language_out + '"';
+      if (options.language_out !== null) {
+        command_line += ' --language_out="' + options.language_out + '"';
       }
 
-      if (options.closure_formatting !== null) {
-        closure_command += ' --formatting="' + options.closure_formatting + '"';
+      if (options.formatting !== null) {
+        command_line += ' --formatting="' + options.formatting + '"';
+      }
+
+      if (typeof options.output_wrapper === 'string') {
+        command_line += ' --output_wrapper="' + options.output_wrapper + '"';
       }
 
       // Add debug param if necessary
-      if (options.closure_debug === true) {
-        closure_command += ' --debug';
+      if (options.debug === true) {
+        command_line += ' --debug';
       }
 
-      if (options.closure_extra_param !== null) {
-        closure_command += ' ' + options.closure_extra_param;
+      if (options.extra_param !== null) {
+        command_line += ' ' + options.extra_param;
       }
+
+      console.log(command_line);
 
       // Closure tools don't create directories, so first we create an empty file at our dest
       grunt.file.write(output_file, '');
 
-      grunt.verbose.writeln(grunt.util.linefeed + 'Execute' + grunt.util.linefeed + closure_command + grunt.util.linefeed);
+      grunt.verbose.writeln(grunt.util.linefeed + 'Execute' + grunt.util.linefeed + command_line + grunt.util.linefeed);
 
       grunt.log.writeln('Input  total size ' + fSrcSizeTotal.toFixed(2) + ' KB');
 
-      exec(closure_command, {maxBuffer: options.exec_maxBuffer * 1024}, function (err, stdout, stderr) {
+      exec(command_line, {maxBuffer: options.exec_maxBuffer * 1024}, function (err, stdout, stderr) {
         if (err) {
           grunt.warn(err);
           compileDone(false);
         } else {
-          if (options.banner.trim() !== "") {
-            var tmpOutputFile = options.banner + grunt.file.read(output_file);
+          if (options.banner.trim() !== '') {
+            var tmpOutputFile = grunt.file.read(output_file);
+            if (options.banner.indexOf('%output%')) {
+              tmpOutputFile = options.banner.replace(/%output%/, tmpOutputFile);
+            } else {
+              tmpOutputFile = options.banner + tmpOutputFile;
+            }
             grunt.file.write(output_file, tmpOutputFile);
           }
 
-          if (options.closure_create_source_map === true) {
-            var tmpOutputMapFile = grunt.file.read(output_file) + grunt.util.linefeed + '//# sourceMappingURL=' + output_mapfile;
-            grunt.file.write(output_file, tmpOutputMapFile);
+          if (options.create_source_map === true) {
+            var tmpOutputMapFile = grunt.file.read(output_mapfile) + grunt.util.linefeed + '//# sourceMappingURL=' + output_mapfile;
+            grunt.file.write(output_mapfile, tmpOutputMapFile);
           }
         }
 


### PR DESCRIPTION
* Because there is no real incompatibility to prefer prefixed versions it's easier to port scripts if `closure-compiler` options and `grunt-google-closure-tools-compiler` options are the same.
* Added Windows JVM support (`javaw`).
* Added new `%output%` variable that can be used in `banner` option to insert compiled js at user-defined position of the banner. If it's missing then js appended as earlier.