### PR TITLE
Some improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
       },
       custom_options_advanced: {
         options: {
-          closure_compilation_level: 'ADVANCED'
+          compilation_level: 'ADVANCED'
         },
         files: {
           'tmp/custom_options_advanced.js': ['test/fixtures/main_custom.js', 'test/fixtures/main_custom_second.js']
@@ -45,10 +45,10 @@ module.exports = function (grunt) {
       },
       custom_options_whitespace_only: {
         options: {
-          closure_compilation_level: 'WHITESPACE_ONLY',
+          compilation_level: 'WHITESPACE_ONLY',
           banner: '/*\n' +
                   ' * Testing\n' +
-                  ' */\n'
+                  ' */\n%output% \n//END'
         },
         files: {
           'tmp/custom_options_whitespace_only.js': ['test/fixtures/main_custom.js', 'test/fixtures/main_custom_second.js']

--- a/README.md
+++ b/README.md
@@ -49,31 +49,31 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 ### Options
 
-#### closure_compilation_level
+#### compilation_level
 
 Choices: `'SIMPLE'`, `'ADVANCED'` , `'WHITESPACE_ONLY'`<br />
 Default: `'SIMPLE'`
 
 Choose which closure compilation level we should use.
 
-#### closure_create_source_map
+#### create_source_map
 
 Type: `Boolean`<br />
 Default: `true`
 
 If `true`, a source map file will be generated in the same directory as the `dest` file. By default it will have the same basename as the `dest` file, but with a `.map` extension.
 
-#### closure_language_in
+#### language_in
 
 Choices: `'ECMASCRIPT3'`, `'ECMASCRIPT5'` , `'ECMASCRIPT5_STRICT'`, `'ECMASCRIPT6'`, `'ECMASCRIPT6_STRICT'`, `'ECMASCRIPT6_TYPED'`<br />
 Default: `'ECMASCRIPT3' (null)`
 
-#### closure_language_out
+#### language_out
 
 Choices: `'ECMASCRIPT3'`, `'ECMASCRIPT5'` , `'ECMASCRIPT5_STRICT'`, `'ECMASCRIPT6_TYPED'`<br />
 Default: `language in`
 
-#### closure_formatting
+#### formatting
 
 Choices: `'PRETTY_PRINT'`, `'PRINT_INPUT_DELIMITER'` , `'SINGLE_QUOTES'`<br />
 Default: `'PRETTY_PRINT' (null)`
@@ -85,7 +85,7 @@ Default: `true`
 
 Turn on closure compiler debug parameter.
 
-#### closure_extra_param
+#### extra_param
 
 Type: `String`<br />
 Default: `null`
@@ -159,10 +159,10 @@ grunt.initConfig({
   googleclosurecompiler: {
     my_target: {
       options: {
-        closure_compilation_level: 'ADVANCED',
+        compilation_level: 'ADVANCED',
         banner: '/*\n' +
                 ' * Minified by closure compiler \n' +
-                ' */\n'
+                ' */\n %output% \n //END'
       },
       files: {
         'dest/output.min.js': ['src/*.js']
@@ -180,7 +180,9 @@ grunt.initConfig({
   googleclosurecompiler: {
     my_target: {
       options: {
-        closure_compilation_level: 'WHITESPACE_ONLY'
+        compilation_level: 'WHITESPACE_ONLY',
+        banner: '// TODO:\n\n'
+      },
       },
       files: {
         'dest/output.min.js': ['src/**']

--- a/docs/closurecompiler-task_examples.md
+++ b/docs/closurecompiler-task_examples.md
@@ -21,7 +21,7 @@ grunt.initConfig({
   googleclosurecompiler: {
     my_target: {
       options: {
-        closure_compilation_level: 'ADVANCED',
+        compilation_level: 'ADVANCED',
         banner: '/*\n' +
                 ' * Minified by closure compiler \n' +
                 ' */\n'
@@ -42,7 +42,7 @@ grunt.initConfig({
   googleclosurecompiler: {
     my_target: {
       options: {
-        closure_compilation_level: 'WHITESPACE_ONLY'
+        compilation_level: 'WHITESPACE_ONLY'
       },
       files: {
         'dest/output.min.js': ['src/**']

--- a/docs/closurecompiler-task_options.md
+++ b/docs/closurecompiler-task_options.md
@@ -1,24 +1,24 @@
-#### closure_compilation_level
+#### compilation_level
 Choices: `'SIMPLE'`, `'ADVANCED'` , `'WHITESPACE_ONLY'`<br />
 Default: `'SIMPLE'`
 
 Choose which closure compilation level we should use.
 
-#### closure_create_source_map
+#### create_source_map
 Type: `Boolean`<br />
 Default: `true`
 
 If `true`, a source map file will be generated in the same directory as the `dest` file. By default it will have the same basename as the `dest` file, but with a `.map` extension.
 
-#### closure_language_in
+#### language_in
 Choices: `'ECMASCRIPT3'`, `'ECMASCRIPT5'` , `'ECMASCRIPT5_STRICT'`, `'ECMASCRIPT6'`, `'ECMASCRIPT6_STRICT'`, `'ECMASCRIPT6_TYPED'`<br />
 Default: `'ECMASCRIPT3' (null)`
 
-#### closure_language_out
+#### language_out
 Choices: `'ECMASCRIPT3'`, `'ECMASCRIPT5'` , `'ECMASCRIPT5_STRICT'`, `'ECMASCRIPT6_TYPED'`<br />
 Default: `language in`
 
-#### closure_formatting
+#### formatting
 Choices: `'PRETTY_PRINT'`, `'PRINT_INPUT_DELIMITER'` , `'SINGLE_QUOTES'`<br />
 Default: `'PRETTY_PRINT' (null)`
 
@@ -28,7 +28,7 @@ Default: `true`
 
 Turn on closure compiler debug parameter.
 
-#### closure_extra_param
+#### extra_param
 Type: `String`<br />
 Default: `null`
 

--- a/tasks/google_closure_compiler.js
+++ b/tasks/google_closure_compiler.js
@@ -10,196 +10,243 @@
 
 'use strict';
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
-  var exec = require('child_process').exec;
-  var fs = require('fs');
-  var _isUndefined = require('lodash/lang/isUndefined');
+var exec = require('child_process').exec;
+var fs = require('fs');
+var readline = require('readline');
+var _isUndefined = require('lodash/lang/isUndefined');
+var _isWin = /^win/.test(process.platform);
 
-  var possible_options = {
+var possible_options = {
     compilation_level: ['SIMPLE', 'ADVANCED', 'WHITESPACE_ONLY'],
     language_in: ['ECMASCRIPT3', 'ECMASCRIPT5', 'ECMASCRIPT5_STRICT', 'ECMASCRIPT6', 'ECMASCRIPT6_STRICT', 'ECMASCRIPT6_TYPED'],
     language_out: ['ECMASCRIPT3', 'ECMASCRIPT5', 'ECMASCRIPT5_STRICT', 'ECMASCRIPT6_TYPED'],
     formatting: ['PRETTY_PRINT', 'PRINT_INPUT_DELIMITER', 'SINGLE_QUOTES']
-  };
+};
 
-  var getFilesizeInBytesfunction = function (filename) {
+var getFilesizeInBytesfunction = function(filename) {
     var stats = fs.statSync(filename);
     var fileSizeInBytes = stats["size"];
     return fileSizeInBytes;
-  };
+};
 //  var path = require('path');
 //  var gzip = require('zlib').gzip;
 
-  grunt.registerMultiTask('closurecompiler', 'A Grunt task for Closure Compiler.', function () {
-    var compileDone = this.async(); // Asynchronous task
+grunt.registerMultiTask('closurecompiler', 'A Grunt task for Closure Compiler.', function() {
+    var self = this,
+        compileDone = this.async(); // Asynchronous task
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      closure_compilation_level: 'SIMPLE',
-      closure_create_source_map: true,
-      closure_language_in: null,
-      closure_language_out: null,
-      closure_formatting: null,
-      closure_debug: false,
-      closure_extra_param: null,
-      banner: '',
-      report_file: '',
-      compiler_jar: 'node_modules/google-closure-compiler/compiler.jar',
-      exec_maxBuffer: 200,
-      java_path: null,
-      java_d32: false,
-      java_tieredcompilation: true
+        compilation_level: 'SIMPLE',
+        create_source_map: true,
+        language_in: null,
+        language_out: null,
+        formatting: null,
+        debug: false,
+        extra_param: null,
+        output_wrapper: null,
+        banner: '',
+        report_file: '',
+        compiler_jar: 'node_modules/google-closure-compiler/compiler.jar',
+        exec_maxBuffer: 200,
+        java_path: null,
+        java_d32: false,
+        java_tieredcompilation: (_isWin ? false : true),
+        spinner: '|/-\\'.split(''),
+        progress_text: '%s Compiling JS file...'
     });
 
     // Check if the compiler_jar property is empty
     if (options.compiler_jar.trim() === "") {
-      grunt.fail.warn('Empty compiler_jar property. No compilation executed...');
-      compileDone(false);
+        grunt.fail.warn('Empty compiler_jar property. No compilation executed...');
+        compileDone(false);
     }
 
     // Check if the files property is empty
     if (this.files.length <= 0) {
-      grunt.fail.warn('Empty files property.');
-      compileDone(false);
-    }
-
-    if (possible_options.compilation_level.indexOf(options.closure_compilation_level) === -1) {
-      grunt.fail.warn('Wrong value for compilation level. (Possible values: ' + possible_options.compilation_level.join(',') + ')');
-      compileDone(false);
-    }
-
-    if (options.closure_language_in !== null) {
-      if (possible_options.language_in.indexOf(options.closure_language_in) === -1) {
-        grunt.fail.warn('Wrong value for language in. (Possible values: ' + possible_options.language_in.join(',') + ')');
+        grunt.fail.warn('Empty files property.');
         compileDone(false);
-      }
     }
 
-    if (options.closure_language_out !== null) {
-      if (possible_options.language_out.indexOf(options.closure_language_out) === -1) {
-        grunt.fail.warn('Wrong value for language out. (Possible values: ' + possible_options.language_out.join(',') + ')');
+    if (possible_options.compilation_level.indexOf(options.compilation_level) === -1) {
+        grunt.fail.warn('Wrong value for compilation level. (Possible values: ' + possible_options.compilation_level.join(',') + ')');
         compileDone(false);
-      }
     }
 
-    if (options.closure_formatting !== null) {
-      if (possible_options.formatting.indexOf(options.closure_formatting) === -1) {
-        grunt.fail.warn('Wrong value for formatting. (Possible values: ' + possible_options.formatting.join(',') + ')');
-        compileDone(false);
-      }
+    if (options.language_in !== null) {
+        if (possible_options.language_in.indexOf(options.language_in) === -1) {
+            grunt.fail.warn('Wrong value for language in. (Possible values: ' + possible_options.language_in.join(',') + ')');
+            compileDone(false);
+        }
     }
 
-    var java_path = 'java';
+    if (options.language_out !== null) {
+        if (possible_options.language_out.indexOf(options.language_out) === -1) {
+            grunt.fail.warn('Wrong value for language out. (Possible values: ' + possible_options.language_out.join(',') + ')');
+            compileDone(false);
+        }
+    }
+
+    if (options.formatting !== null) {
+        if (possible_options.formatting.indexOf(options.formatting) === -1) {
+            grunt.fail.warn('Wrong value for formatting. (Possible values: ' + possible_options.formatting.join(',') + ')');
+            compileDone(false);
+        }
+    }
+
+    var java_path = 'java' + (_isWin ? 'w' : '');
 
     // If we have setted JAVA_HOME we would prefer this
     if (!_isUndefined(process.env.JAVA_HOME)) {
-      java_path = process.env.JAVA_HOME + '/bin/java';
+        java_path = process.env.JAVA_HOME + '/bin/java' + (_isWin ? 'w' : '');
     }
 
     // At least the user can set it by config
     if (options.java_path !== null) {
-      java_path = options.java_path;
+        java_path = options.java_path;
     }
 
     // Java command with optional parameters
-    var command = java_path + ' ' +
-            (options.java_d32 === true ? '-client -d32 ' : '') +
-            (options.java_tieredcompilation === true ? '-server -XX:+TieredCompilation ' : '') +
-            '-jar "' + options.compiler_jar + '"';
+    var java_command = java_path + ' ' +
+        (options.java_d32 === true ? '-client -d32 ' : '') +
+        (options.java_tieredcompilation === true ? '-server -XX:+TieredCompilation ' : '') +
+        '-jar "' + options.compiler_jar + '"';
 
-    this.files.forEach(function (f) {
-      grunt.verbose.writeflags(f.src, "Input files");
+    this.files.forEach(function(f) {
+        grunt.verbose.writeflags(f.src, "Input files");
 
-      if (f.src.length === 0) {
-        grunt.fail.warn('No javascript files given');
-        compileDone(false);
-      }
-
-      var output_file = f.dest;
-      var output_mapfile = output_file + '.map';
-      var output_reportFile = options.report_file || output_file + '.report.txt';
-      var fSrcSizeTotal = 0.0;
-      var fileInputArray = [];
-      f.src.forEach(function (fSrc) {
-        if (fSrc !== output_file) {
-          fileInputArray.push(fSrc);
-
-          var fSrcSize = getFilesizeInBytesfunction(fSrc) / 1000.0;
-          grunt.verbose.writeln('Input ' + fSrc + ' (' + fSrcSize.toFixed(2) + ' KB)');
-          fSrcSizeTotal += fSrcSize;
-        }
-      });
-
-      var javascript_files = '--js="' + fileInputArray.join('" --js="') + '"';
-      var closure_command = command + ' ' + javascript_files + ' --js_output_file="' + output_file + '"';
-
-      // Add compilation level
-      closure_command += ' --compilation_level="' + options.closure_compilation_level + '"';
-
-      // Add source map param if necessary
-      if (options.closure_create_source_map === true) {
-        closure_command += ' --create_source_map="' + output_mapfile + '"';
-      }
-
-      if (options.closure_language_in !== null) {
-        closure_command += ' --language_in="' + options.closure_language_in + '"';
-      }
-
-      if (options.closure_language_out !== null) {
-        closure_command += ' --language_out="' + options.closure_language_out + '"';
-      }
-
-      if (options.closure_formatting !== null) {
-        closure_command += ' --formatting="' + options.closure_formatting + '"';
-      }
-
-      // Add debug param if necessary
-      if (options.closure_debug === true) {
-        closure_command += ' --debug';
-      }
-
-      if (options.closure_extra_param !== null) {
-        closure_command += ' ' + options.closure_extra_param;
-      }
-
-      // Closure tools don't create directories, so first we create an empty file at our dest
-      grunt.file.write(output_file, '');
-
-      grunt.verbose.writeln(grunt.util.linefeed + 'Execute' + grunt.util.linefeed + closure_command + grunt.util.linefeed);
-
-      grunt.log.writeln('Input  total size ' + fSrcSizeTotal.toFixed(2) + ' KB');
-
-      exec(closure_command, {maxBuffer: options.exec_maxBuffer * 1024}, function (err, stdout, stderr) {
-        if (err) {
-          grunt.warn(err);
-          compileDone(false);
-        } else {
-          if (options.banner.trim() !== "") {
-            var tmpOutputFile = options.banner + grunt.file.read(output_file);
-            grunt.file.write(output_file, tmpOutputFile);
-          }
-
-          if (options.closure_create_source_map === true) {
-            var tmpOutputMapFile = grunt.file.read(output_file) + grunt.util.linefeed + '//# sourceMappingURL=' + output_mapfile;
-            grunt.file.write(output_file, tmpOutputMapFile);
-          }
+        if (f.src.length === 0) {
+            grunt.fail.warn('No javascript files given');
+            compileDone(false);
         }
 
-        var outputSize = getFilesizeInBytesfunction(output_file) / 1000;
-        var minifiedPercent = (outputSize.toFixed(2) / (fSrcSizeTotal.toFixed(2) / 100));
+        var output_file = f.dest,
+            current = 0,
+            output_mapfile = output_file + '.map',
+            output_reportFile = options.report_file || output_file + '.report.txt',
+            fSrcSizeTotal = 0.0,
+            fileInputArray = [];
 
-        grunt.log.writeln('Output total size ' + outputSize.toFixed(2) + ' KB [' + (minifiedPercent > 0 ? '-' + (100 - minifiedPercent) : '0') + '%]');
-        grunt.verbose.writeln('Output file ' + output_file);
-
-        if (stdout) {
-          grunt.log.writeln(stdout);
+        if (typeof f.src === 'string') {
+            f.src = [f.src];
         }
 
-        grunt.log.ok('Compiled succesfully.');
-        compileDone();
-      });
+        f.src.forEach(function(fSrc) {
+            if (fSrc !== output_file) {
+                fileInputArray.push(fSrc);
+
+                var fSrcSize = getFilesizeInBytesfunction(fSrc) / 1000.0;
+                grunt.verbose.writeln('Input ' + fSrc + ' (' + fSrcSize.toFixed(2) + ' KB)');
+                fSrcSizeTotal += fSrcSize;
+            }
+        });
+
+        var javascript_files = '--js="' + fileInputArray.join('" --js="') + '"';
+        var command_line = '';
+
+        if (_isWin) {
+            if (typeof options.output_wrapper === 'string') {
+                options.output_wrapper = options.output_wrapper.replace(/[\r\n]+/, ' ');
+            }
+        }
+
+        command_line += java_command + ' ' + javascript_files + ' --js_output_file="' + output_file + '"';
+
+        // Add compilation level
+        command_line += ' --compilation_level="' + options.compilation_level + '"';
+
+        // Add source map param if necessary
+        if (options.create_source_map === true) {
+            command_line += ' --create_source_map="' + output_mapfile + '"';
+        }
+
+        if (options.language_in !== null) {
+            command_line += ' --language_in="' + options.language_in + '"';
+        }
+
+        if (options.language_out !== null) {
+            command_line += ' --language_out="' + options.language_out + '"';
+        }
+
+        if (options.formatting !== null) {
+            command_line += ' --formatting="' + options.formatting + '"';
+        }
+
+        if (typeof options.output_wrapper === 'string') {
+            command_line += ' --output_wrapper="' + options.output_wrapper + '"';
+        }
+
+        // Add debug param if necessary
+        if (options.debug === true) {
+            command_line += ' --debug';
+        }
+
+        if (options.extra_param !== null) {
+            command_line += ' ' + options.extra_param;
+        }
+
+        //console.log(command_line);
+
+        // Closure tools don't create directories, so first we create an empty file at our dest
+        grunt.file.write(output_file, '');
+
+        grunt.verbose.writeln(grunt.util.linefeed + 'Execute' + grunt.util.linefeed + command_line + grunt.util.linefeed);
+
+        grunt.log.writeln('Input  total size ' + fSrcSizeTotal.toFixed(2) + ' KB');
+
+        if (process.stdout) {
+            self.id = setInterval(function() {
+                readline.clearLine(process.stdout, 0);
+                readline.cursorTo(process.stdout, 0);
+                process.stdout.write(options.progress_text.replace('%s', options.spinner[current]));
+                current = ++current % options.spinner.length;
+            }, 100);
+        }
+
+        exec(command_line, { maxBuffer: options.exec_maxBuffer * 1024 }, function(err, stdout, stderr) {
+            if (err) {
+                grunt.warn(err);
+                compileDone(false);
+            } else {
+                if (options.banner.trim() !== '') {
+                    var tmpOutputFile = grunt.file.read(output_file);
+                    if (~options.banner.indexOf('%output%')) {
+                        tmpOutputFile = options.banner.replace(/%output%/, tmpOutputFile);
+                    } else {
+                        tmpOutputFile = options.banner + tmpOutputFile;
+                    }
+                    grunt.file.write(output_file, tmpOutputFile);
+                }
+
+                if (options.create_source_map === true) {
+                    var tmpOutputMapFile = grunt.file.read(output_mapfile) + grunt.util.linefeed + '//# sourceMappingURL=' + output_mapfile;
+                    grunt.file.write(output_mapfile, tmpOutputMapFile);
+                }
+            }
+
+            var outputSize = getFilesizeInBytesfunction(output_file) / 1000;
+            var minifiedPercent = (outputSize.toFixed(2) / (fSrcSizeTotal.toFixed(2) / 100));
+
+            if (process.stdout) {
+                clearInterval(self.id);
+                self.id = undefined;
+                readline.clearLine(process.stdout, 0);
+                readline.cursorTo(process.stdout, 0);
+            }
+
+            grunt.log.writeln('Output total size ' + outputSize.toFixed(2) + ' KB [' + (minifiedPercent > 0 ? '-' + (100 - minifiedPercent) : '0') + '%]');
+            grunt.verbose.writeln('Output file ' + output_file);
+
+            if (stdout) {
+                grunt.log.writeln(stdout);
+            }
+
+            grunt.log.ok('Compiled succesfully.');
+            compileDone();
+        });
     });
-  });
+});
 
 };


### PR DESCRIPTION
Added Windows `javaw` support
Added `%output%` code insertion point option to `banner` property
Nice spinner animation on progress
Because there is no real incompatibility between them it's easier to port scripts from/to tasks like [grunt-closure-compiler](https://www.npmjs.com/package/grunt-closure-compiler)/[grunt-node-closure-compiler](https://www.npmjs.com/package/grunt-node-closure-compiler) and [grunt-google-closure-tools-compiler](https://www.npmjs.com/package/grunt-google-closure-tools-compiler) if options are the same