### PR TITLE
(bugfix) Wait for all the files to finish compiling before ending the task

### DIFF
--- a/tasks/google_closure_compiler.js
+++ b/tasks/google_closure_compiler.js
@@ -17,6 +17,7 @@ var fs = require('fs');
 var readline = require('readline');
 var _isUndefined = require('lodash/lang/isUndefined');
 var _isWin = /^win/.test(process.platform);
+var async = grunt.util.async;
 
 var possible_options = {
     compilation_level: ['SIMPLE', 'ADVANCED', 'WHITESPACE_ONLY'],
@@ -114,7 +115,7 @@ grunt.registerMultiTask('closurecompiler', 'A Grunt task for Closure Compiler.',
         (options.java_tieredcompilation === true ? '-server -XX:+TieredCompilation ' : '') +
         '-jar "' + options.compiler_jar + '"';
 
-    this.files.forEach(function(f) {
+    async.forEach(this.files, function(f) {
         grunt.verbose.writeflags(f.src, "Input files");
 
         if (f.src.length === 0) {
@@ -242,10 +243,10 @@ grunt.registerMultiTask('closurecompiler', 'A Grunt task for Closure Compiler.',
             if (stdout) {
                 grunt.log.writeln(stdout);
             }
-
-            grunt.log.ok('Compiled succesfully.');
-            compileDone();
         });
+    }, function (error) {
+        grunt.log.ok('Compiled succesfully.');
+        compileDone(!error);
     });
 });
 


### PR DESCRIPTION
When trying to compile more than one file the task will finish when the first file is finished. 
The rest of the files will eventually be compiled, but the grunt task will be finished long before. 

This bug causes some issues in continuous integration development, especially if after the grunt task you try to use the compiled files in the next build step (for example run some tests).  Because the closurecompiler task finishes before actually compiling all the files, the next task in the build process will try to use those files but will fail, as they are still being processed.